### PR TITLE
[Feature] Less log lines

### DIFF
--- a/minetestmod/mumble/init.lua
+++ b/minetestmod/mumble/init.lua
@@ -3,6 +3,7 @@ local serverinfo
 local minetestversion = string.gsub(minetest.get_version().string, '%.', '')
 minetestversion = tonumber(minetestversion)
 local timer = 0
+local previous_info = {}
 
 minetest.register_globalstep(function(dtime)
 	if minetest.localplayer and not player then
@@ -35,6 +36,14 @@ minetest.register_globalstep(function(dtime)
 			camera_look = minetest.camera:get_look_dir()
 			player_look = camera_look
 		end
-		minetest.log("action", "mumble submit pp=["..(player_pos.x).." "..(player_pos.y).." "..(player_pos.z).."] pl=["..(player_look.x).." "..(player_look.y).." "..(player_look.z).."] cp=["..(camera_pos.x).." "..(camera_pos.y).." "..(camera_pos.z).."] cl=["..(camera_look.x).." "..(camera_look.y).." "..(camera_look.z).."]")
+		if not(previous_info.player_pos == player_pos and previous_info.player_look == player_look and previous_info.camera_pos == camera_pos and previous_info.camera_look == camera_look) then
+			minetest.log("action", "mumble submit pp=["..(player_pos.x).." "..(player_pos.y).." "..(player_pos.z).."] pl=["..(player_look.x).." "..(player_look.y).." "..(player_look.z).."] cp=["..(camera_pos.x).." "..(camera_pos.y).." "..(camera_pos.z).."] cl=["..(camera_look.x).." "..(camera_look.y).." "..(camera_look.z).."]")
+			previous_info = {
+				player_pos = player_pos,
+				player_look = player_look,
+				camera_pos = camera_pos,
+				camera_look = camera_look,
+			}
+		end
 	end
 end)

--- a/minetestmod/mumble/init.lua
+++ b/minetestmod/mumble/init.lua
@@ -12,7 +12,7 @@ minetest.register_globalstep(function(dtime)
 		minetest.log("action", "mumble context "..serverinfo.ip..":"..serverinfo.port)
 		minetest.display_chat_message("!Mumble loaded! This mod uses print() to send ingame positional data, so your debug.txt may get quite large, and it's recommended to set debug_log_level to nothing if you haven't already.")
 	end
-    if player then
+	if player then
 		timer = timer + dtime
 		if timer > 1 then
 			serverinfo = minetest.get_server_info()
@@ -20,25 +20,21 @@ minetest.register_globalstep(function(dtime)
 			minetest.log("action", "mumble context "..serverinfo.ip..":"..serverinfo.port)
 			timer = 0
 		end
-        local player_pos = player:get_pos() or {x=0, y=0, z=0}
-        local player_look = {x=0, y=0, z=0}
-        local camera_pos = {x=0, y=0, z=0}
-        local camera_look = {x=0, y=0, z=0}
-        if minetest.camera then
-            camera_pos = minetest.camera:get_pos()
+		local player_pos = player:get_pos() or {x=0, y=0, z=0}
+		local player_look = {x=0, y=0, z=0}
+		local camera_pos = {x=0, y=0, z=0}
+		local camera_look = {x=0, y=0, z=0}
+		if minetest.camera then
+			camera_pos = minetest.camera:get_pos()
 			--before Minetest 5.2.0 camera positions were 10x player position.
 			if minetestversion and minetestversion <= 520 then
 				camera_pos.x = (camera_pos.x/10)
 				camera_pos.y = (camera_pos.y/10)
 				camera_pos.z = (camera_pos.z/10)
 			end
-            camera_look = minetest.camera:get_look_dir()
-            player_look = camera_look
-        end
-        minetest.log("action", "p p ["..(player_pos.x).." "..(player_pos.y).." "..(player_pos.z).."]")
-        minetest.log("action", "p l ["..(player_look.x).." "..(player_look.y).." "..(player_look.z).."]")
-        minetest.log("action", "c p ["..(camera_pos.x).." "..(camera_pos.y).." "..(camera_pos.z).."]")
-        minetest.log("action", "c l ["..(camera_look.x).." "..(camera_look.y).." "..(camera_look.z).."]")
-        minetest.log("action", "mumble submit")
-    end
+			camera_look = minetest.camera:get_look_dir()
+			player_look = camera_look
+		end
+		minetest.log("action", "mumble submit pp=["..(player_pos.x).." "..(player_pos.y).." "..(player_pos.z).."] pl=["..(player_look.x).." "..(player_look.y).." "..(player_look.z).."] cp=["..(camera_pos.x).." "..(camera_pos.y).." "..(camera_pos.z).."] cl=["..(camera_look.x).." "..(camera_look.y).." "..(camera_look.z).."]")
+	end
 end)

--- a/minetestmod/mumble/mod.conf
+++ b/minetestmod/mumble/mod.conf
@@ -1,0 +1,1 @@
+name = mumble


### PR DESCRIPTION
Hi,

I made some changes to make this CSM log less, whilst keeping the same functionality.

- I have put every position related data into one `minetest.log('mumble submit <positiondata>')`
- Changed the main.rs to match that
- Made it so that it will only log once the data is changed. So if you're standing still, it won't log anything (except for the `mumble context` and `mumble id` messages)
- Also made the whole code the same indentation
- Added `mod.conf` with `name = mumble`

I hope it will be added, since it reduces a lot of logs